### PR TITLE
Fix for Incorrect directory separator for Unix

### DIFF
--- a/LBORO/Vehicle Model/ElectricalManagementClass.py
+++ b/LBORO/Vehicle Model/ElectricalManagementClass.py
@@ -78,6 +78,6 @@ class ElectricalManagementClass(ElectricalDeviceClass.ElectricalDevice):
         counter = 0
         even_share = [elec.i / length(battery_array)] * length(battery_array)
 
-        while (counter < 5):
+        # while (counter < 5):
             
         

--- a/LBORO/Vehicle Model/main.py
+++ b/LBORO/Vehicle Model/main.py
@@ -25,7 +25,7 @@ feed_forward = False
 ###############################
 ###   TEST DATAFILE NAME    ###
 ###############################
-filename     = "DriveCycles\WLTP_kph"
+filename     = "DriveCycles/WLTP_kph"
 #filename     = "realcycle_kph"
 
 


### PR DESCRIPTION
This is a fix for issue https://github.com/howroyd/ELEVATE/issues/13

I also commented out an unused while loop, but feel free to discard this change.